### PR TITLE
[#67] 토큰을 받아오지 못하는 문제 해결

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -50,7 +50,11 @@ export class AuthController {
             console.log(`${state} / ${error}: ${error_description}`);
             return { ok: false, error: '카카오 로그인에 실패했습니다.' };
         }
+        return { ok: true };
+    }
 
+    @Get('token')
+    getJwtToken(@Query() { code }: KakaoRedirectInput) {
         return this.authService.getJwt(code);
     }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
+    ApiBadRequestResponse,
     ApiBearerAuth,
     ApiExcludeEndpoint,
     ApiOkResponse,
@@ -13,7 +14,11 @@ import { AccessTokenGuard } from './auth.guard';
 import { AuthService } from './auth.service';
 import { AuthJwtDecoded } from './dtos/auth-jwt-core';
 import { GetKakoLoginUrlOutput } from './dtos/get-kakak-login-url.dto';
-import { UnlinkTokenOutput } from './dtos/get-token.dto';
+import {
+    GetJwtInput,
+    GetJwtOutput,
+    UnlinkTokenOutput,
+} from './dtos/get-token.dto';
 import { KakaoRedirectInput } from './dtos/kakao-redirect.dto';
 
 @ApiTags('인증')
@@ -53,8 +58,21 @@ export class AuthController {
         return { ok: true };
     }
 
+    @ApiOperation({
+        summary: '인증 가능한 토큰을 발급',
+        description:
+            '/auth/kakaoLoginRedirect에서 url로 받은 토큰을 가지고 본 API로 요청시 인증 가능한 토큰을 발급받을 수 있음.',
+    })
+    @ApiOkResponse({
+        description: '토큰 정상 발급',
+        type: GetJwtOutput,
+    })
+    @ApiBadRequestResponse({
+        description: '토큰 발급 실패 ',
+        type: GetJwtOutput,
+    })
     @Get('token')
-    getJwtToken(@Query() { code }: KakaoRedirectInput) {
+    getJwtToken(@Query() { code }: GetJwtInput): Promise<GetJwtOutput> {
         return this.authService.getJwt(code);
     }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -56,7 +56,7 @@ export class AuthService {
 
             return { ok: true, token: jwtToken };
         } catch (error) {
-            console.log(error);
+            console.log(error.stack, error.message);
             return {
                 ok: false,
                 error: '회원 인증에 실패했습니다',
@@ -115,7 +115,7 @@ export class AuthService {
             return kakaoTokens;
         } catch (error) {
             error.message += `\n 
-            error args at getKakaoAccessToken \n
+            error args at getKakaoToken \n
             code: ${code}
             `;
             throw error;

--- a/src/auth/dtos/get-token.dto.ts
+++ b/src/auth/dtos/get-token.dto.ts
@@ -1,11 +1,15 @@
+import { PickType } from '@nestjs/swagger';
 import { IsJWT, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
 import { CoreOutput } from 'src/common/dtos/output.dto';
+import { KakaoRedirectInput } from './kakao-redirect.dto';
 
 export class GetJwtOutput extends CoreOutput {
     @IsJWT()
     @IsOptional()
     token?: string;
 }
+
+export class GetJwtInput extends PickType(KakaoRedirectInput, ['code']) {}
 
 export class UnlinkTokenOutput extends CoreOutput {}
 

--- a/src/auth/dtos/kakao-redirect.dto.ts
+++ b/src/auth/dtos/kakao-redirect.dto.ts
@@ -3,24 +3,27 @@ import { IsOptional, IsString } from 'class-validator';
 
 export class KakaoRedirectInput {
     @ApiPropertyOptional({
-        description: '카카오 토큰을 발급받는 코드',
+        description: '카카오 토큰을 발급받는 코드.',
     })
     @IsString()
     code: string;
 
     @ApiPropertyOptional({
-        description: 'CSRF 공격 차단을 위한 파라미터',
+        description:
+            'CSRF 공격 차단을 위한 파라미터. 아직 개발되지는 않았지만, 카카오 공식문서애 표시되어 있어서 넣었습니다.',
     })
     state?: string;
 
     @ApiPropertyOptional({
-        description: '카카오 에러 코드',
+        description:
+            '카카오 에러 코드. 코드 발급 중 에러 발생시에만 넘겨줍니다.',
     })
     @IsOptional()
     error?: string;
 
     @ApiPropertyOptional({
-        description: '카카오 에러 설명',
+        description:
+            '카카오 에러 설명. 코드 발급 중 에러 발생시에만 넘겨줍니다.',
     })
     @IsOptional()
     error_description?: string;


### PR DESCRIPTION
### Description
- 카카오에서 발급받은 code는 일회용이어서 서버에서 사용해서 토큰을 발급해버리면 클라이언트에서 토큰을 받아올 수가 없다.
- 따라서 리다이렉트 URL로 서버에 요청이 들어왔을 때 바로 토큰을 발급해주는 대신, 클라이언트에서 code를 가지고 서버에 요청해서 토큰을 받아오는 방법으로 변경하였다.
<img width="1215" alt="스크린샷 2021-10-03 오후 6 36 00" src="https://user-images.githubusercontent.com/61102178/135748057-67435e3e-0f80-4d40-8c90-6deefa1245a8.png">

### Related Issues
#71 