### PR TITLE
[#100] 배포환경에서 로그인 문제 해결

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -72,8 +72,8 @@ export class AuthController {
         type: GetJwtOutput,
     })
     @Get('token')
-    getJwtToken(@Query() { code }: GetJwtInput): Promise<GetJwtOutput> {
-        return this.authService.getJwt(code);
+    getJwtToken(@Query() getJwtInput: GetJwtInput): Promise<GetJwtOutput> {
+        return this.authService.getJwt(getJwtInput);
     }
 
     @ApiOperation({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { MembersService } from 'src/members/members.service';
 import {
+    GetJwtInput,
     GetJwtOutput,
     GetKakaoTokenOutput,
     UnlinkTokenOutput,
@@ -39,14 +40,16 @@ export class AuthService {
         }
     }
 
-    async getJwt(code: string): Promise<GetJwtOutput> {
+    async getJwt(getJwtInput: GetJwtInput): Promise<GetJwtOutput> {
         try {
-            const kakaoTokens = await this.getKakaoToken(code);
+            const { code, redirectUrl } = getJwtInput;
+            const kakaoTokens = await this.getKakaoToken(code, redirectUrl);
             const mbrKakaoSeq = await this.getMbrKakaoSeq(
                 kakaoTokens.accessToken,
             );
-            const { ok, error, member } =
-                await this.memberService.getMemberByKakaoSeq(mbrKakaoSeq);
+            const { member } = await this.memberService.getMemberByKakaoSeq(
+                mbrKakaoSeq,
+            );
 
             const jwtToken = this.createJwt(
                 member?.mbrSeq,
@@ -84,10 +87,13 @@ export class AuthService {
         }
     }
 
-    private async getKakaoToken(code: string): Promise<GetKakaoTokenOutput> {
+    private async getKakaoToken(
+        code: string,
+        redirectUrl: string,
+    ): Promise<GetKakaoTokenOutput> {
         try {
             const hostName = this.configService.get('KAKAO_LOGIN_HOST');
-            const baseDomain = this.configService.get('BASE_DOMAIN');
+            const baseDomain = redirectUrl;
 
             const url = `https://${hostName}/oauth/token`;
 
@@ -116,7 +122,8 @@ export class AuthService {
         } catch (error) {
             error.message += `\n 
             error args at getKakaoToken \n
-            code: ${code}
+            code: ${code} \n
+            response body: ${error.response.body}
             `;
             throw error;
         }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,7 +10,6 @@ import {
     UnlinkTokenOutput,
 } from './dtos/get-token.dto';
 import * as camelcaseKeys from 'camelcase-keys';
-import { Member } from 'src/members/entities/members.entity';
 import { GetKakoLoginUrlOutput } from './dtos/get-kakak-login-url.dto';
 
 @Injectable()

--- a/src/auth/dtos/get-token.dto.ts
+++ b/src/auth/dtos/get-token.dto.ts
@@ -1,4 +1,4 @@
-import { PickType } from '@nestjs/swagger';
+import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsJWT, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
 import { CoreOutput } from 'src/common/dtos/output.dto';
 import { KakaoRedirectInput } from './kakao-redirect.dto';
@@ -9,7 +9,15 @@ export class GetJwtOutput extends CoreOutput {
     token?: string;
 }
 
-export class GetJwtInput extends PickType(KakaoRedirectInput, ['code']) {}
+export class GetJwtInput extends PickType(KakaoRedirectInput, ['code']) {
+    @ApiProperty({
+        description:
+            '리다이렉트할 url입니다. ex) http://localhost:3000/auth/kakaoLoginRedirect(O), https://www.wavy.dance/auth/kakaoLoginRedirect(O), https://wavy.dance(X) www.wavy.dance(X)',
+        type: String,
+    })
+    @IsString()
+    redirectUrl: string;
+}
 
 export class UnlinkTokenOutput extends CoreOutput {}
 

--- a/src/auth/dtos/get-token.dto.ts
+++ b/src/auth/dtos/get-token.dto.ts
@@ -12,7 +12,7 @@ export class GetJwtOutput extends CoreOutput {
 export class GetJwtInput extends PickType(KakaoRedirectInput, ['code']) {
     @ApiProperty({
         description:
-            '리다이렉트할 url입니다. ex) http://localhost:3000/auth/kakaoLoginRedirect(O), https://www.wavy.dance/auth/kakaoLoginRedirect(O), https://wavy.dance(X) www.wavy.dance(X)',
+            '리다이렉트할 url입니다. ex) http://localhost:3000/auth/kakaoLoginRedirect(X), https://www.wavy.dance/auth/kakaoLoginRedirect(X), https://wavy.dance(O)',
         type: String,
     })
     @IsString()

--- a/src/auth/dtos/kakao-redirect.dto.ts
+++ b/src/auth/dtos/kakao-redirect.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsUrl } from 'class-validator';
 
 export class KakaoRedirectInput {
     @ApiPropertyOptional({
@@ -10,7 +10,7 @@ export class KakaoRedirectInput {
 
     @ApiPropertyOptional({
         description:
-            'CSRF 공격 차단을 위한 파라미터. 아직 개발되지는 않았지만, 카카오 공식문서애 표시되어 있어서 넣었습니다.',
+            'CSRF 공격 차단을 위한 파라미터. 아직 개발되지는 않았지만, 카카오 공식문서에 표시되어 있어서 넣었습니다.',
     })
     state?: string;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,6 @@ async function bootstrap() {
     app.enableCors({
         origin: corsOrigins,
         methods: corsMethods,
-        allowedHeaders: corsHeaders,
     });
 
     const swaggerConfig = new DocumentBuilder()

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -172,9 +172,9 @@ export class MembersService {
 
         switch (member.certificationMethodCode) {
             case MemberCertificationMethodCode.KAKAO:
-                member.mbrKakaoSeq = '0';
+                member.mbrKakaoSeq = null;
             default:
-                member.mbrKakaoSeq = '0';
+                member.mbrKakaoSeq = null;
         }
 
         await this.members.save(member);
@@ -212,6 +212,7 @@ export class MembersService {
 
             return { ok: true };
         } catch (error) {
+            console.log(error.message, error.stack);
             return { ok: false, error: '회원 정보 삭제에 실패했습니다.' };
         }
     }


### PR DESCRIPTION
### Description
- 원인: 카카오 토큰을 발급받을시 redirect url을 환경변수로 설정하였음. 때문에 다양한 클라이언트 (localhost, 테스트 서버, wavy.dance 등)의 요청에 응답할수가 없었음.
- 해결: GET /auth/token에 query로 redirect url을 받아서 처리.
- swagger 문서를 보면 어떤 url을 넣어야 하는지 예시를 적어놓았습니다.

### Related Issue
#100 