### PR TITLE
[#92] POST /analyses 버그 해결

### DIFF
--- a/src/analyses/analyses.controller.ts
+++ b/src/analyses/analyses.controller.ts
@@ -7,6 +7,7 @@ import {
     Post,
     Query,
     UseGuards,
+    UseInterceptors,
 } from '@nestjs/common';
 import {
     ApiBearerAuth,
@@ -22,6 +23,7 @@ import { MemberGuard } from 'src/auth/auth.guard';
 import { AuthJwtDecoded } from 'src/auth/dtos/auth-jwt-core';
 import { CoreOutput } from 'src/common/dtos/output.dto';
 import { PaginationInput } from 'src/common/dtos/pagination.dto';
+import { TimeoutInterceptor } from 'src/common/timeout.interceptor';
 import { Member } from 'src/members/entities/members.entity';
 import { AnalysesService } from './analyses.service';
 import { CreateAnalysisRequestInput } from './dtos/create-analysis-request.dto';
@@ -109,6 +111,7 @@ export class AnalysesController {
         description: '사용자 영상 분석을 Queue에 등록하는 API입니다.',
     })
     @Post()
+    @UseInterceptors(TimeoutInterceptor)
     @UseGuards(MemberGuard)
     createAnalysisRequest(
         @AuthMember() member: Member,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -90,6 +90,10 @@ import { Lambda, S3, SharedIniFileCredentials } from 'aws-sdk';
                 credentials: new SharedIniFileCredentials({
                     profile: process.env.AWS_PROFILE,
                 }),
+                // TODO: convert mp4 Lambda to async...
+                httpOptions: {
+                    timeout: 300000,
+                },
             },
             services: [S3, Lambda],
         }),

--- a/src/common/timeout.interceptor.ts
+++ b/src/common/timeout.interceptor.ts
@@ -1,0 +1,27 @@
+import {
+    Injectable,
+    NestInterceptor,
+    ExecutionContext,
+    CallHandler,
+    RequestTimeoutException,
+} from '@nestjs/common';
+import { Observable, throwError, TimeoutError } from 'rxjs';
+import { catchError, timeout } from 'rxjs/operators';
+
+const millisecondInMin = 1000 * 60;
+const timeOutMinute = 5;
+
+@Injectable()
+export class TimeoutInterceptor implements NestInterceptor {
+    intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+        return next.handle().pipe(
+            timeout(timeOutMinute * millisecondInMin),
+            catchError((err) => {
+                if (err instanceof TimeoutError) {
+                    return throwError(new RequestTimeoutException());
+                }
+                return throwError(err);
+            }),
+        );
+    }
+}


### PR DESCRIPTION
### Description
- 문제상황: 비디오 업로드시 Timeout Error 발생
- 원인: 비디오 업로드 후 .webm에서 .mp4로 변환하는데 시간이 많이 소요되어 timeout이 발생함.
- 해결: .webm에서 .mp4로 변환하는 람다함수를 aws sdk를 이용해 비동기로 호출하여 해결

### Related Issue
#92 