### PR TITLE
[#112] 분석중에 GET /analyses/{seq} 호출시 에러 발생

### DIFF
--- a/src/analyses/analyses.service.ts
+++ b/src/analyses/analyses.service.ts
@@ -157,16 +157,9 @@ export class AnalysesService {
                 .andWhere('an.an_deleted = false')
                 .getOne();
 
-            const simularityFilename = `${this.configService.get(
-                'AWS_AN_JSON_BUCKET_ENDPOINT',
-            )}/${analysis.anSimularityFilename}`;
-
-            const userVideoMotionDataFilename = `${this.configService.get(
-                'AWS_AN_JSON_BUCKET_ENDPOINT',
-            )}/${analysis.anUserVideoMotionDataFilename}`;
-
-            const simularityJson = await got.get(simularityFilename).json();
-            // const userVideoMotionDataJson = await got.get(userVideoMotionDataFilename)
+            const simularityJson = this.getSimularityJson(
+                analysis.anSimularityFilename,
+            );
 
             return { ok: true, analysis: analysis, simularityJson };
         } catch (error) {
@@ -175,6 +168,18 @@ export class AnalysesService {
                 ok: false,
                 error: '분석 결과를 불러오지 못했습니다.',
             };
+        }
+    }
+
+    private async getSimularityJson(simularityFilename: string) {
+        try {
+            const simularityFullPath = `${this.configService.get(
+                'AWS_AN_JSON_BUCKET_ENDPOINT',
+            )}/${simularityFilename}`;
+            const simularityJson = await got.get(simularityFullPath).json();
+            return simularityJson;
+        } catch {
+            return {};
         }
     }
 


### PR DESCRIPTION
### Description
#### 문제상황
분석 요청이 잘 들어가서 분석 중에 GET /analyses/{seq} 호출시 에러가 발생함

#### 원인
GET /analyses/{seq} 호출시 유사도 Json을 받아오는 GET요청을 내부적으로 날리는데, 예외처리를 따로하지 않았음.

#### 해결
GET 요청을 다른 함수로 빼서 그 함수에서 예외처리를 하고, 에러 발생시 빈 값을 리턴하도록 처리.

### Related Issue
#112 